### PR TITLE
Update for Neo4j 5.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,19 @@
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-faker</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
     <properties>
-        <neo4j.version>4.4.0</neo4j.version>
+        <neo4j.version>5.26.0</neo4j.version>
+        <lang3.version>3.17.0</lang3.version>
         <artifactId>neo4jFaker</artifactId>
-        <version>0.9.5</version>
+        <version>0.9.6</version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${lang3.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
@@ -28,7 +34,7 @@
         <dependency>
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
-            <version>0.13</version>
+            <version>1.0.2</version>
         </dependency>
     </dependencies>
     <build>
@@ -68,10 +74,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,7 @@
+# 0.9.6
+* maintenance
+* Updated pom.xml to support 5.26.0 LTS
+
 # 0.9.5
 
 * maintenance


### PR DESCRIPTION
Update pom.xml to be compatible with Neo4j 5.26.0
Updated specific apache commons library within pom.xml